### PR TITLE
Constrain ray_demo:raylib to CPython 3.8.

### DIFF
--- a/ray_demo/BUILD
+++ b/ray_demo/BUILD
@@ -1,13 +1,10 @@
 python_library(
     name = "raylib",
-    sources=["*.py"],
-    
-    # dependencies = [],
+    interpreter_constraints = ["CPython==3.8.*"]
 )
 pex_binary(
     dependencies=[":raylib"],
     entry_point="ray_demo.rayburst",
-    #execution_mode='zipapp',
     name = "ray_demo",
     execution_mode= 'venv',
 )


### PR DESCRIPTION
Since raylib depends on ray and ray only supports CPython 3.{6,7,8}, we need
to constrain its interpreter to match available ray wheels.

See the available wheels here: https://pypi.org/project/ray/1.2.0/#files